### PR TITLE
Fix security alert on jquery 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5810,9 +5810,9 @@ jest@^24.0.0:
     jest-cli "^24.0.0"
 
 jquery@x.*:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
`semantic-ui-css` has a dependency on `jquery@x.*`
This was resolved to 3.3.1, but that has some issues.

Updated jquery manually ( since it's a x.* dependency ) to 3.4.1 